### PR TITLE
Replace Distribute with Setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author_email='ruslan.spivak@gmail.com',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=['distribute', 'paramiko'],
+    install_requires=['setuptools>=0.7', 'paramiko'],
     zip_safe=False,
     entry_points="""\
     [console_scripts]


### PR DESCRIPTION
According to [Distribute official website][1]:

> _Distribute_ is a deprecated fork of the _Setuptools_ project.
>
> Since the Setuptools 0.7 release, Setuptools and Distribute have merged and Distribute is no longer being maintained. All ongoing effort should reference the [Setuptools project][2] and the [Setuptools documentation][3].

Also, according to [Setuptools’ changelog][4]:

> 2013-06-02 10:46 -0400

> - Merged Setuptools and Distribute. See [docs/merge.txt][5] for details.

[1]: https://pythonhosted.org/distribute/
[2]: https://bitbucket.org/pypa/setuptools
[3]: https://pythonhosted.org/setuptools
[4]: http://pythonhosted.org/setuptools/history.html#id194
[5]: https://bitbucket.org/pypa/setuptools/src/18.2/docs/merge.txt