### PR TITLE
List available auth mechanisms.

### DIFF
--- a/src/sftpserver/stub_sftp.py
+++ b/src/sftpserver/stub_sftp.py
@@ -37,6 +37,10 @@ class StubServer (ServerInterface):
     def check_channel_request(self, kind, chanid):
         return OPEN_SUCCEEDED
 
+    def get_allowed_auths(self, username):
+        """List availble auth mechanisms."""
+        return "password,publickey"
+
 
 class StubSFTPHandle (SFTPHandle):
     def stat(self):


### PR DESCRIPTION
"publickey" declared as an allowed auth mechanism.

By default, only "password" is allowed.

See http://docs.paramiko.org/en/2.0/api/server.html#paramiko.server.ServerInterface.get_allowed_auths