### PR TITLE
don't exit sftpserver if fail to read SSH protocol banner

### DIFF
--- a/src/sftpserver/__init__.py
+++ b/src/sftpserver/__init__.py
@@ -49,19 +49,21 @@ def start_server(host, port, keyfile, level):
 
     while True:
         conn, addr = server_socket.accept()
+        try:
+            host_key = paramiko.RSAKey.from_private_key_file(keyfile)
+            transport = paramiko.Transport(conn)
+            transport.add_server_key(host_key)
+            transport.set_subsystem_handler(
+                'sftp', paramiko.SFTPServer, StubSFTPServer)
 
-        host_key = paramiko.RSAKey.from_private_key_file(keyfile)
-        transport = paramiko.Transport(conn)
-        transport.add_server_key(host_key)
-        transport.set_subsystem_handler(
-            'sftp', paramiko.SFTPServer, StubSFTPServer)
+            server = StubServer()
+            transport.start_server(server=server)
 
-        server = StubServer()
-        transport.start_server(server=server)
-
-        channel = transport.accept()
-        while transport.is_active():
-            time.sleep(1)
+            channel = transport.accept()
+            while transport.is_active():
+                time.sleep(1)
+        except Exception as ex:
+            print ex
 
 
 def main():


### PR DESCRIPTION
often get the following errors and the sftpserver exit, we don't want the sftpserver exit if SSH protocol banner not received for one connection.

DEBUG:paramiko.transport:starting thread (server mode): 0x38102dd0L
DEBUG:paramiko.transport:Local version/idstring: SSH-2.0-paramiko_2.4.1
ERROR:paramiko.transport:Exception: Error reading SSH protocol banner
ERROR:paramiko.transport:Traceback (most recent call last):
ERROR:paramiko.transport:  File "/usr/lib/python2.7/site-packages/paramiko/transport.py", line 1893, in run
ERROR:paramiko.transport:    self._check_banner()
ERROR:paramiko.transport:  File "/usr/lib/python2.7/site-packages/paramiko/transport.py", line 2049, in _check_banner
ERROR:paramiko.transport:    'Error reading SSH protocol banner' + str(e)
ERROR:paramiko.transport:SSHException: Error reading SSH protocol banner
ERROR:paramiko.transport:
Traceback (most recent call last):
  File "/usr/bin/sftpserver", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/sftpserver/__init__.py", line 96, in main
    start_server(args.host, args.port, args.keyfile, args.level)
  File "/usr/lib/python2.7/site-packages/sftpserver/__init__.py", line 60, in start_server
    transport.start_server(server=server)
  File "/usr/lib/python2.7/site-packages/paramiko/transport.py", line 614, in start_server
    raise e
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner